### PR TITLE
fix(atomic): guarantee alignment in struct

### DIFF
--- a/engine/base-server.go
+++ b/engine/base-server.go
@@ -34,10 +34,13 @@ var errorMessages map[int]string = map[int]string{
 }
 
 type server struct {
+	// clientsCount has to be first in the struct to guarantee alignment for atomic
+	// operations. http://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	clientsCount uint64
+
 	events.EventEmitter
 
 	clients        *sync.Map
-	clientsCount   uint64
 	corsMiddleware func(*types.HttpContext, types.Callable)
 	opts           config.ServerOptionsInterface
 

--- a/events/events.go
+++ b/events/events.go
@@ -212,10 +212,13 @@ func (e *emmiter) On(evt EventName, listener ...Listener) error {
 }
 
 type oneTimelistener struct {
+	// fired has to be first in the struct to guarantee alignment for atomic
+	// operations. http://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	fired int32
+
 	evt        EventName
 	emitter    *emmiter
 	listener   Listener
-	fired      int32
 	executeRef Listener
 }
 


### PR DESCRIPTION
It affected us on ARM architecture where it panicked with panic: unaligned 64-bit atomic operation.
See: http://golang.org/pkg/sync/atomic/#pkg-note-BUG

Also see: https://github.com/zishang520/socket.io/pull/10